### PR TITLE
Increase java package version for latest node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "functional_tests": "./node_modules/jasmine-node/bin/jasmine-node test/functional"
   },
   "dependencies": {
-    "java": "0.7.2",
+    "java": "0.9.1",
     "js2xmlparser": "1.0.0",
     "xml2js": "0.4.17"
   },


### PR DESCRIPTION
The java package prior to version 0.8 has v8 compilation errors with newer versions of node. All tests passing:

`15 tests, 15 assertions, 0 failures, 0 skipped`
`15 tests, 15 assertions, 0 failures, 0 skipped`
`49 tests, 123 assertions, 0 failures, 0 skipped`