### PR TITLE
set java classpath once

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,17 +3,17 @@ var java = require('java');
 var xml2js = require('xml2js');
 var path = require('path');
 
-var NodeHL7Complete = function(options) {
-  var javaBridgeParser = null;
-  var javaClassDependencies = [
-    path.join(__dirname, 'java_dependencies', 'node-hl7-complete-3.0.0-SNAPSHOT.jar'),
-    path.join(__dirname, 'java_dependencies', 'hapi-base-2.2.jar'),
-    path.join(__dirname, 'java_dependencies', 'slf4j-api-1.7.16.jar'),
-    path.join(__dirname, 'java_dependencies', 'hapi-osgi-base-2.2.jar')
-  ];
+var javaClassDependencies = [
+  path.join(__dirname, 'java_dependencies', 'node-hl7-complete-3.0.0-SNAPSHOT.jar'),
+  path.join(__dirname, 'java_dependencies', 'hapi-base-2.2.jar'),
+  path.join(__dirname, 'java_dependencies', 'slf4j-api-1.7.16.jar'),
+  path.join(__dirname, 'java_dependencies', 'hapi-osgi-base-2.2.jar')
+];
 
-  java.classpath = java.classpath.concat(javaClassDependencies);
-  javaBridgeParser = java.newInstanceSync('node_hl7_complete.hl7.Parser');
+java.classpath = java.classpath.concat(javaClassDependencies);
+
+var NodeHL7Complete = function(options) {
+  var javaBridgeParser = java.newInstanceSync('node_hl7_complete.hl7.Parser');
 
   // This will set HL7 validation off/on. It is true by default in the Java impl.
   var setStrictMode = function(trueOrFalse) {


### PR DESCRIPTION
Earlier, class path was being set inside the `NodeHL7Complete` class, causing node-java to throw the following error when trying to instantiate multiple instances of `NodeHL7Complete`

```sh
/Users/mathew/Projects/trials/node-hl7-trial/node_modules/node-hl7-complete/index.js:15
  java.classpath = java.classpath.concat(javaClassDependencies);
                 ^

Error: Cannot set classpath after calling any other java function.
    at new NodeHL7Complete (/Users/mathew/Projects/trials/node-hl7-trial/node_modules/node-hl7-complete/index.js:15:18)
    at Object.<anonymous> (/Users/mathew/Projects/trials/node-hl7-trial/index.js:4:31)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
```
